### PR TITLE
feat: add expose_key option to pass in sentry_key secret

### DIFF
--- a/.changes/unreleased/Added-20260507-133736.yaml
+++ b/.changes/unreleased/Added-20260507-133736.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added option to expose sentry key for direct reuse
+time: 2026-05-07T13:37:36.154818227+02:00

--- a/internal/config.go
+++ b/internal/config.go
@@ -7,6 +7,7 @@ type BaseConfig struct {
 	RateLimitCount   *int   `mapstructure:"rate_limit_count"`
 	Project          string `mapstructure:"project"`
 	TrackDeployments *bool  `mapstructure:"track_deployments"`
+	ExposeKey        *bool  `mapstructure:"expose_key"`
 }
 
 // GlobalConfig global Sentry configuration.
@@ -17,10 +18,13 @@ type GlobalConfig struct {
 	Organization string `mapstructure:"organization"`
 }
 
-var defaultGlobalConfig = GlobalConfig{
-	BaseConfig: BaseConfig{
-		TrackDeployments: boolPtr(true),
-	},
+func newGlobalConfig() GlobalConfig {
+	return GlobalConfig{
+		BaseConfig: BaseConfig{
+			TrackDeployments: boolPtr(true),
+			ExposeKey:        boolPtr(false),
+		},
+	}
 }
 
 // SiteConfig is for site specific sentry DSN settings
@@ -29,8 +33,10 @@ type SiteConfig struct {
 	Components map[string]SiteComponentConfig `mapstructure:"-"`
 }
 
-var defaultSiteConfig = SiteConfig{
-	Components: map[string]SiteComponentConfig{},
+func newSiteConfig() SiteConfig {
+	return SiteConfig{
+		Components: map[string]SiteComponentConfig{},
+	}
 }
 
 // SiteComponentConfig is for component specific sentry DSN settings
@@ -65,6 +71,9 @@ func (c *SiteConfig) extendGlobalConfig(g GlobalConfig) SiteConfig {
 	if c.TrackDeployments != nil {
 		cfg.TrackDeployments = c.TrackDeployments
 	}
+	if c.ExposeKey != nil {
+		cfg.ExposeKey = c.ExposeKey
+	}
 	return cfg
 }
 
@@ -87,6 +96,9 @@ func (c *SiteComponentConfig) extendSiteConfig(s SiteConfig) SiteComponentConfig
 	}
 	if c.TrackDeployments != nil {
 		cfg.TrackDeployments = c.TrackDeployments
+	}
+	if c.ExposeKey != nil {
+		cfg.ExposeKey = c.ExposeKey
 	}
 	return cfg
 }

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"embed"
 	"fmt"
+	"strings"
 	"sync"
 
 	_ "dario.cat/mergo"
@@ -71,7 +72,7 @@ func (p *SentryPlugin) SetGlobalConfig(data map[string]any) error {
 		return fmt.Errorf("invalid global config: %w", err)
 	}
 
-	cfg := defaultGlobalConfig
+	cfg := newGlobalConfig()
 	if err := mapstructure.Decode(data, &cfg); err != nil {
 		return err
 	}
@@ -84,7 +85,7 @@ func (p *SentryPlugin) SetSiteConfig(site string, data map[string]any) error {
 		return fmt.Errorf("invalid site config for site %s: %w", site, err)
 	}
 
-	cfg := defaultSiteConfig
+	cfg := newSiteConfig()
 	if err := mapstructure.Decode(data, &cfg); err != nil {
 		return err
 	}
@@ -104,7 +105,7 @@ func (p *SentryPlugin) SetSiteComponentConfig(site string, component string, dat
 
 	siteCfg, ok := p.siteConfigs[site]
 	if !ok {
-		siteCfg = defaultSiteConfig
+		siteCfg = newSiteConfig()
 		p.siteConfigs[site] = siteCfg
 	}
 	siteCfg.Components[component] = cfg
@@ -171,13 +172,27 @@ func (p *SentryPlugin) RenderTerraformComponent(site string, component string) (
 		return nil, err
 	}
 
-	vars := fmt.Sprintf("sentry_dsn = \"%s\"", siteComponentConfig.DSN)
+	var vars []string
 	if p.globalConfig.AuthToken != "" {
-		vars = fmt.Sprintf("sentry_dsn = sentry_key.%s.dsn_secret", component)
+		vars = append(vars,
+			fmt.Sprintf("sentry_dsn = sentry_key.%s.dsn_secret", component),
+		)
+		if siteComponentConfig.ExposeKey != nil && *siteComponentConfig.ExposeKey {
+			vars = append(vars,
+				fmt.Sprintf("sentry_key = sentry_key.%s.secret", component),
+			)
+		}
+	} else {
+		vars = append(vars,
+			fmt.Sprintf("sentry_dsn = \"%s\"", siteComponentConfig.DSN),
+		)
+		if siteComponentConfig.ExposeKey != nil && *siteComponentConfig.ExposeKey {
+			hclog.Default().Warn("expose_key is set to true but auth_token is not configured; sentry_key will not be available", "site", site, "component", component)
+		}
 	}
 
 	result := &schema.ComponentSchema{
-		Variables: vars,
+		Variables: strings.Join(vars, "\n"),
 	}
 
 	if !p.IsEnabled() {
@@ -199,7 +214,7 @@ func (p *SentryPlugin) RenderTerraformComponent(site string, component string) (
 func (p *SentryPlugin) getSiteConfig(site string) SiteConfig {
 	cfg, ok := p.siteConfigs[site]
 	if !ok {
-		cfg = defaultSiteConfig
+		cfg = newSiteConfig()
 	}
 	return cfg.extendGlobalConfig(p.globalConfig)
 }

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -33,6 +33,7 @@ func TestSetGlobalConfigFull(t *testing.T) {
 			RateLimitWindow:  intPtr(1000),
 			RateLimitCount:   intPtr(10),
 			TrackDeployments: boolPtr(true),
+			ExposeKey:        boolPtr(false),
 			Project:          "test",
 		},
 		AuthToken:    "foobar",
@@ -62,6 +63,7 @@ func TestSetGlobalConfigDefaults(t *testing.T) {
 			RateLimitWindow:  nil,
 			RateLimitCount:   nil,
 			TrackDeployments: boolPtr(true),
+			ExposeKey:        boolPtr(false),
 		},
 	}, p.globalConfig)
 }
@@ -79,6 +81,7 @@ func TestSetGlobalConfigWithFalse(t *testing.T) {
 			RateLimitWindow:  nil,
 			RateLimitCount:   nil,
 			TrackDeployments: boolPtr(false),
+			ExposeKey:        boolPtr(false),
 		},
 	}, p.globalConfig)
 }
@@ -174,6 +177,117 @@ func TestSetSiteComponentConfigInvalid(t *testing.T) {
 		"bar": "baz",
 	})
 	assert.Error(t, err)
+}
+
+func TestRenderTerraformComponentWithoutAuthToken(t *testing.T) {
+	p := NewSentryPlugin()
+
+	p.SetGlobalConfig(map[string]any{})
+	p.SetSiteComponentConfig("my-site", "my-component", map[string]any{
+		"dsn": "https://sentry.io/123",
+	})
+	p.SetComponentConfig("my-component", "abc123", map[string]any{})
+
+	result, err := p.RenderTerraformComponent("my-site", "my-component")
+	assert.NoError(t, err)
+	assert.Equal(t, `sentry_dsn = "https://sentry.io/123"`, result.Variables)
+	assert.Empty(t, result.Resources)
+}
+
+func TestRenderTerraformComponentWithoutAuthTokenButExposeKey(t *testing.T) {
+	p := NewSentryPlugin()
+
+	p.SetGlobalConfig(map[string]any{
+		"expose_key": true,
+	})
+	p.SetSiteComponentConfig("my-site", "my-component", map[string]any{
+		"dsn": "https://sentry.io/123",
+	})
+	p.SetComponentConfig("my-component", "abc123", map[string]any{})
+
+	result, err := p.RenderTerraformComponent("my-site", "my-component")
+	assert.NoError(t, err)
+	assert.Equal(t, `sentry_dsn = "https://sentry.io/123"`, result.Variables)
+	assert.NotContains(t, result.Variables, "sentry_key =")
+	assert.Empty(t, result.Resources)
+}
+
+func TestRenderTerraformComponentWithAuthToken(t *testing.T) {
+	p := NewSentryPlugin()
+
+	p.SetGlobalConfig(map[string]any{
+		"auth_token":   "foobar",
+		"organization": "my-org",
+	})
+	p.SetSiteComponentConfig("my-site", "my-component", map[string]any{
+		"dsn": "https://sentry.io/123",
+	})
+	p.SetComponentConfig("my-component", "abc123", map[string]any{})
+
+	result, err := p.RenderTerraformComponent("my-site", "my-component")
+	assert.NoError(t, err)
+	assert.Contains(t, result.Variables, "sentry_dsn = sentry_key.my-component.dsn_secret")
+	assert.NotContains(t, result.Variables, "sentry_key =")
+}
+
+func TestRenderTerraformComponentWithExposeKeyGlobal(t *testing.T) {
+	p := NewSentryPlugin()
+
+	p.SetGlobalConfig(map[string]any{
+		"auth_token":   "foobar",
+		"organization": "my-org",
+		"expose_key":   true,
+	})
+	p.SetSiteComponentConfig("my-site", "my-component", map[string]any{
+		"dsn": "https://sentry.io/123",
+	})
+	p.SetComponentConfig("my-component", "abc123", map[string]any{})
+
+	result, err := p.RenderTerraformComponent("my-site", "my-component")
+	assert.NoError(t, err)
+	assert.Contains(t, result.Variables, "sentry_dsn = sentry_key.my-component.dsn_secret")
+	assert.Contains(t, result.Variables, "sentry_key = sentry_key.my-component.secret")
+}
+
+func TestRenderTerraformComponentWithExposeKeySiteOverride(t *testing.T) {
+	p := NewSentryPlugin()
+
+	p.SetGlobalConfig(map[string]any{
+		"auth_token":   "foobar",
+		"organization": "my-org",
+		"expose_key":   true,
+	})
+	p.SetSiteConfig("my-site", map[string]any{
+		"expose_key": false,
+	})
+	p.SetSiteComponentConfig("my-site", "my-component", map[string]any{
+		"dsn": "https://sentry.io/123",
+	})
+	p.SetComponentConfig("my-component", "abc123", map[string]any{})
+
+	result, err := p.RenderTerraformComponent("my-site", "my-component")
+	assert.NoError(t, err)
+	assert.Contains(t, result.Variables, "sentry_dsn = sentry_key.my-component.dsn_secret")
+	assert.NotContains(t, result.Variables, "sentry_key =")
+}
+
+func TestRenderTerraformComponentWithExposeKeyComponentOverride(t *testing.T) {
+	p := NewSentryPlugin()
+
+	p.SetGlobalConfig(map[string]any{
+		"auth_token":   "foobar",
+		"organization": "my-org",
+	})
+	p.SetSiteComponentConfig("my-site", "my-component", map[string]any{
+		"dsn":        "https://sentry.io/123",
+		"expose_key": true,
+	})
+	p.SetComponentConfig("my-component", "abc123", map[string]any{})
+
+	result, err := p.RenderTerraformComponent("my-site", "my-component")
+	assert.NoError(t, err)
+	assert.Contains(t, result.Variables, "sentry_dsn = sentry_key.my-component.dsn_secret")
+	assert.Contains(t, result.Variables, "sentry_key = sentry_key.my-component.secret")
 }
 
 func TestSetComponentConfig(t *testing.T) {

--- a/internal/schemas/global-config.json
+++ b/internal/schemas/global-config.json
@@ -28,6 +28,11 @@
       "type": "boolean",
       "description": "Whether to track release deployments in Sentry.",
       "default": true
+    },
+    "expose_key": {
+      "type": "boolean",
+      "description": "Whether to expose the sentry key as a variable to the component.",
+      "default": false
     }
   }
 }

--- a/internal/schemas/site-component-config.json
+++ b/internal/schemas/site-component-config.json
@@ -19,6 +19,11 @@
       "type": "boolean",
       "description": "Whether to track release deployments in Sentry.",
       "default": true
+    },
+    "expose_key": {
+      "type": "boolean",
+      "description": "Whether to expose the sentry key as a variable to the component.",
+      "default": false
     }
   }
 }

--- a/internal/schemas/site-config.json
+++ b/internal/schemas/site-config.json
@@ -19,6 +19,11 @@
       "type": "boolean",
       "description": "Whether to track release deployments in Sentry.",
       "default": true
+    },
+    "expose_key": {
+      "type": "boolean",
+      "description": "Whether to expose the sentry key as a variable to the component.",
+      "default": false
     }
   }
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/xeipuuv/gojsonschema"
 )
 


### PR DESCRIPTION
This pull request adds support for exposing the Sentry key as a variable to components, controlled via a new `expose_key` configuration option at the global, site, and site-component levels. The feature is implemented with appropriate schema updates, configuration struct changes, logic in the rendering process, and comprehensive test coverage.

**New Feature: Expose Sentry Key Option**

* Added a new boolean `ExposeKey` field to `BaseConfig`, with default values set in `GlobalConfig` and proper propagation through `SiteConfig` and `SiteComponentConfig` extension logic. [[1]](diffhunk://#diff-0cb36811c5ab07631529c9e82697352bb620d50cf5f88e3e5503bb3e85441caaR10) [[2]](diffhunk://#diff-0cb36811c5ab07631529c9e82697352bb620d50cf5f88e3e5503bb3e85441caaR24) [[3]](diffhunk://#diff-0cb36811c5ab07631529c9e82697352bb620d50cf5f88e3e5503bb3e85441caaR70-R72) [[4]](diffhunk://#diff-0cb36811c5ab07631529c9e82697352bb620d50cf5f88e3e5503bb3e85441caaR96-R98)
* Updated configuration schemas (`global-config.json`, `site-config.json`, `site-component-config.json`) to include the new `expose_key` option with documentation and default value. [[1]](diffhunk://#diff-463c78cde6b79e4f5897e5ee5b50972156dffed14169919f8dbfb40257fc425dR31-R35) [[2]](diffhunk://#diff-c189d58c35395b6a3be7befb936c19e758f32609f50b0040fba9d38b8534ae20R22-R26) [[3]](diffhunk://#diff-038a5775ec8ab6e3915069cfba9fbac079a6dbec1657250ba3ab15cd48607f44R22-R26)

**Terraform Rendering Logic**

* Modified `RenderTerraformComponent` to conditionally add the `sentry_key` variable based on the `expose_key` setting, ensuring the Sentry key is only exposed when explicitly enabled.

**Testing**

* Added and updated tests in `plugin_test.go` to verify the behavior of the new `expose_key` option at all configuration levels and its effect on Terraform variable rendering. [[1]](diffhunk://#diff-0cb7fa1a625d3276eb1677173c169baccef2141d8e93b22bd9a09706a5d3afcbR36) [[2]](diffhunk://#diff-0cb7fa1a625d3276eb1677173c169baccef2141d8e93b22bd9a09706a5d3afcbR66) [[3]](diffhunk://#diff-0cb7fa1a625d3276eb1677173c169baccef2141d8e93b22bd9a09706a5d3afcbR84) [[4]](diffhunk://#diff-0cb7fa1a625d3276eb1677173c169baccef2141d8e93b22bd9a09706a5d3afcbR182-R274)

**Documentation**

* Added a changelog entry documenting the addition of the option to expose the Sentry key for direct reuse.

**Code Cleanup**

* Minor import reordering and cleanup in `plugin.go`.